### PR TITLE
Panthronics contribution

### DIFF
--- a/src/jisa/addresses/USBAddress.java
+++ b/src/jisa/addresses/USBAddress.java
@@ -1,5 +1,7 @@
 package jisa.addresses;
 
+import jisa.devices.DeviceException;
+
 import javax.usb.UsbDevice;
 import javax.usb.UsbDeviceDescriptor;
 import java.util.ArrayList;
@@ -34,6 +36,26 @@ public class USBAddress implements Address {
 
     public USBAddress(int manufacturer, int model) {
         this(-1, manufacturer, model, null);
+    }
+
+    public USBAddress(String address) throws DeviceException
+    {
+        if (!address.contains("USB") && !address.contains("INSTR"))
+        {
+            throw new DeviceException("Address is not not USB address, does not contain USB and INSTR");
+        }
+
+        String[] addressSplit = address.split("::");
+
+        int manufacturer = Integer.decode(addressSplit[1]);
+        int model = Integer.decode(addressSplit[2]);
+        String serialNumber = addressSplit[3];
+
+        this.board           = -1;
+        this.manufacturer    = manufacturer;
+        this.model           = model;
+        this.serialNumber    = serialNumber;
+        this.interfaceNumber = -1;
     }
 
     public static USBAddress fromUSBDevice(UsbDevice device) {

--- a/src/jisa/devices/interfaces/DCPower.java
+++ b/src/jisa/devices/interfaces/DCPower.java
@@ -131,6 +131,15 @@ public interface DCPower extends IVSource {
     double getVoltageLimit() throws IOException, DeviceException;
 
     /**
+     * Sets the current protection limit
+     *
+     * @param current limit [A]
+     * @throws IOException     Upon communication error
+     * @throws DeviceException Upon device compatibility error
+     */
+    void setCurrentLimit(double current) throws IOException, DeviceException;
+
+    /**
      * Wait for the voltage output of the supply to be stable within the given percentage margin and time-frame
      *
      * @param pctError Margin of error, percentage

--- a/src/jisa/devices/interfaces/IVSource.java
+++ b/src/jisa/devices/interfaces/IVSource.java
@@ -9,10 +9,6 @@ public interface IVSource extends ISource, VSource {
         return "Current and Voltage Source";
     }
 
-    /*
-     * On Jisa update add functions below to interface.
-     */
-
     /**
      * Get the default value or the value set by the setCurrent() method.
      * @return current setting [A]

--- a/src/jisa/devices/interfaces/IVSource.java
+++ b/src/jisa/devices/interfaces/IVSource.java
@@ -1,9 +1,27 @@
 package jisa.devices.interfaces;
 
+import jisa.devices.DeviceException;
+import java.io.IOException;
+
 public interface IVSource extends ISource, VSource {
 
     public static String getDescription() {
         return "Current and Voltage Source";
     }
 
+    /*
+     * On Jisa update add functions below to interface.
+     */
+
+    /**
+     * Get the default value or the value set by the setCurrent() method.
+     * @return current setting [A]
+     */
+    double getSetCurrent() throws DeviceException, IOException;
+
+    /**
+     * Get the default value or the value set by the setVoltage() method.
+     * @return voltage setting [V]
+     */
+    double getSetVoltage() throws DeviceException, IOException;
 }

--- a/src/jisa/devices/interfaces/MCSMU.java
+++ b/src/jisa/devices/interfaces/MCSMU.java
@@ -1628,6 +1628,17 @@ public interface MCSMU extends SMU, MultiChannel<SMU> {
             return smu;
         }
 
+        @Override
+        public double getSetCurrent() throws DeviceException, IOException
+        {
+            throw new DeviceException("Not implemented.");
+        }
+
+        @Override
+        public double getSetVoltage() throws DeviceException, IOException
+        {
+            throw new DeviceException("Not implemented.");
+        }
     }
 
 }

--- a/src/jisa/devices/power/AgilentE3644A.java
+++ b/src/jisa/devices/power/AgilentE3644A.java
@@ -28,6 +28,18 @@ public class AgilentE3644A extends VISADevice implements DCPower {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented");
+    }
+
+    @Override
     public void turnOn() throws IOException, DeviceException {
         write("OUTPUT:STATE ON");
     }
@@ -96,4 +108,9 @@ public class AgilentE3644A extends VISADevice implements DCPower {
         return queryDouble("VOLTAGE:PROTECTION:LEVEL?");
     }
 
+    @Override
+    public void setCurrentLimit(double current) throws IOException, DeviceException
+    {
+        throw new DeviceException("Device not available");
+    }
 }

--- a/src/jisa/devices/power/K2200.java
+++ b/src/jisa/devices/power/K2200.java
@@ -47,6 +47,18 @@ public class K2200 extends VISADevice implements DCPower {
 
     }
 
+    @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented");
+    }
+
     public double getVoltage() throws IOException {
         return queryDouble(C_QUERY_VOLTAGE);
     }
@@ -70,6 +82,12 @@ public class K2200 extends VISADevice implements DCPower {
     @Override
     public double getVoltageLimit() throws IOException, DeviceException {
         return queryInt("VOLT:PROP:STAT?") == 1 ? queryDouble("VOLT:PROP:LEVEL?") : 0;
+    }
+
+    @Override
+    public void setCurrentLimit(double current) throws IOException, DeviceException
+    {
+        throw new DeviceException("Device not available");
     }
 
     public void setVoltage(double voltage) throws IOException {

--- a/src/jisa/devices/power/TSX3510P.java
+++ b/src/jisa/devices/power/TSX3510P.java
@@ -32,6 +32,18 @@ public class TSX3510P extends VISADevice implements DCPower {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented");
+    }
+
+    @Override
     public void turnOn() throws IOException, DeviceException {
         write("OP 1");
         on = true;
@@ -74,6 +86,12 @@ public class TSX3510P extends VISADevice implements DCPower {
 
     public double getVoltageLimit() throws IOException {
         return Double.parseDouble(query("OVP?").substring(4));
+    }
+
+    @Override
+    public void setCurrentLimit(double current) throws IOException, DeviceException
+    {
+        throw new DeviceException("Device not available");
     }
 
     public void setDeltaI(double current) throws IOException {

--- a/src/jisa/devices/smu/Agilent4155X.java
+++ b/src/jisa/devices/smu/Agilent4155X.java
@@ -26,6 +26,18 @@ public class Agilent4155X extends Agilent415XX {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     protected AgilentRange rangeFromVoltage(int channel, double voltage) {
         return VoltRange.fromVoltage(UnitType.SMU, voltage);
     }

--- a/src/jisa/devices/smu/Agilent4156X.java
+++ b/src/jisa/devices/smu/Agilent4156X.java
@@ -26,6 +26,18 @@ public class Agilent4156X extends Agilent415XX {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     protected AgilentRange rangeFromVoltage(int channel, double voltage) {
         return VoltRange.fromVoltage(UnitType.SMU, voltage);
     }

--- a/src/jisa/devices/smu/AgilentB1500A.java
+++ b/src/jisa/devices/smu/AgilentB1500A.java
@@ -27,6 +27,18 @@ public class AgilentB1500A extends Agilent415XX {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     protected void updateIntTime(int channel) throws IOException {
 
         if (lastIntTime != intTimes[channel]) {

--- a/src/jisa/devices/smu/DummyMCSMU.java
+++ b/src/jisa/devices/smu/DummyMCSMU.java
@@ -27,6 +27,18 @@ public class DummyMCSMU implements MCSMU {
     private static Cleaner   cleaner = Cleaner.create();
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     public String getChannelName(int channel) {
         String[] values = {"A", "B", "C", "D"};
         return "SMU " + values[channel];

--- a/src/jisa/devices/smu/K236.java
+++ b/src/jisa/devices/smu/K236.java
@@ -694,6 +694,18 @@ public class K236 extends VISADevice implements SMU {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     public void setIntegrationTime(double time) throws IOException {
         write(C_SET_INT_TIME, IntTime.fromDouble(time).toInt());
     }

--- a/src/jisa/devices/smu/K2400.java
+++ b/src/jisa/devices/smu/K2400.java
@@ -29,6 +29,18 @@ public class K2400 extends KeithleySCPI {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     public String getChannelName() {
         return "Keithley 2400 SMU";
     }

--- a/src/jisa/devices/smu/K2450.java
+++ b/src/jisa/devices/smu/K2450.java
@@ -59,6 +59,18 @@ public class K2450 extends KeithleySCPI {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        return queryDouble(":SOUR:CURR?");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        return queryDouble(":SOUR:VOLT?");
+    }
+
+    @Override
     public String getChannelName() {
         return "Main Channel";
     }

--- a/src/jisa/devices/smu/K2600B.java
+++ b/src/jisa/devices/smu/K2600B.java
@@ -102,6 +102,18 @@ public class K2600B extends VISADevice implements MCSMU {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     public String getChannelName(int channel) {
 
         switch (channel) {

--- a/src/jisa/devices/smu/K6430.java
+++ b/src/jisa/devices/smu/K6430.java
@@ -27,6 +27,18 @@ public class K6430 extends KeithleySCPI {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     public TType getTerminalType(Terminals terminals) {
 
         switch (terminals) {

--- a/src/jisa/devices/smu/KeithleySCPI.java
+++ b/src/jisa/devices/smu/KeithleySCPI.java
@@ -132,11 +132,9 @@ public abstract class KeithleySCPI extends VISADevice implements SMU {
         addAutoRemove("\n");
 
         write(":SYSTEM:CLEAR");
-        /** TODO replacable? */
         write(":TRAC:CLE"); // clears all readings and statistics from default buffer
         write(":STAT:CLE"); // clears event registers and the event log
-        /***/
-        manuallyClearReadBuffer();
+        //manuallyClearReadBuffer();
         setAverageMode(AMode.NONE);
 
         LINE_FREQUENCY = queryDouble(C_QUERY_LFR);

--- a/src/jisa/devices/smu/KeithleySCPI.java
+++ b/src/jisa/devices/smu/KeithleySCPI.java
@@ -132,6 +132,10 @@ public abstract class KeithleySCPI extends VISADevice implements SMU {
         addAutoRemove("\n");
 
         write(":SYSTEM:CLEAR");
+        /** TODO replacable? */
+        write(":TRAC:CLE"); // clears all readings and statistics from default buffer
+        write(":STAT:CLE"); // clears event registers and the event log
+        /***/
         manuallyClearReadBuffer();
         setAverageMode(AMode.NONE);
 

--- a/src/jisa/devices/smu/SMUCluster.java
+++ b/src/jisa/devices/smu/SMUCluster.java
@@ -77,6 +77,18 @@ public class SMUCluster implements MCSMU {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     public String getChannelName(int channel) {
         try {
             checkChannel(channel);

--- a/src/jisa/devices/smu/TestFET.java
+++ b/src/jisa/devices/smu/TestFET.java
@@ -55,6 +55,18 @@ public class TestFET implements MCSMU {
     }
 
     @Override
+    public double getSetCurrent() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
+    public double getSetVoltage() throws DeviceException, IOException
+    {
+        throw new DeviceException("Not implemented.");
+    }
+
+    @Override
     public String getChannelName(int channel) {
 
         switch (channel) {

--- a/src/jisa/gui/GUI.java
+++ b/src/jisa/gui/GUI.java
@@ -1,6 +1,6 @@
 package jisa.gui;
 
-import javafx.JavaFX;
+//import javafx.JavaFx;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;

--- a/src/jisa/gui/JavaFX.java
+++ b/src/jisa/gui/JavaFX.java
@@ -1,0 +1,68 @@
+package jisa.gui;
+
+import jisa.Util;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import javafx.stage.Stage;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.concurrent.Semaphore;
+
+public class JavaFX {
+
+    public static void launch() {
+
+        // Start-up the JavaFx GUI thread
+        try {
+            Thread t = new Thread(() -> Application.launch(App.class));
+            t.start();
+            Platform.setImplicitExit(false);
+        } catch (Exception ignored) {
+
+        }
+
+        Semaphore semaphore = new Semaphore(0);
+
+        int RETRY_COUNT = 10;
+        int count = 0;
+        while(true)
+        {
+            try
+            {
+                Util.sleep((100L * count));
+                Platform.runLater(semaphore::release);
+                break;
+            }
+            catch (IllegalStateException e)
+            {
+                if(++count == RETRY_COUNT) throw e;
+            }
+        }
+
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException ignored) {}
+
+    }
+
+
+    public static class App extends Application {
+
+        public final static Semaphore s = new Semaphore(0);
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            s.release();
+        }
+
+    }
+
+}

--- a/src/jisa/visa/RSVISADriver.java
+++ b/src/jisa/visa/RSVISADriver.java
@@ -1,0 +1,600 @@
+package jisa.visa;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.NativeLongByReference;
+import jisa.Util;
+import jisa.addresses.Address;
+import jisa.addresses.SerialAddress;
+import jisa.addresses.StrAddress;
+import jisa.visa.Connection;
+import jisa.visa.Driver;
+import jisa.visa.VISAException;
+import jisa.visa.VISANativeInterface;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static jisa.visa.VISANativeInterface.*;
+
+public class RSVISADriver implements Driver
+{
+
+    private static final String              OS_NAME          = System.getProperty("os.name").toLowerCase();
+    private static final String              responseEncoding = "UTF8";
+    private static final long                VISA_ERROR       = 0x7FFFFFFF;
+    private static final int                 _VI_ERROR        = -2147483648;
+    private static final int                 VI_SUCCESS       = 0;
+    private static final int                 VI_NULL          = 0;
+    private static final int                 VI_TRUE          = 1;
+    private static final int                 VI_FALSE         = 0;
+    private static jisa.visa.VISANativeInterface libStatic;
+    private static       String              libName;
+    private static       NativeLong          visaResourceManagerHandleStatic;
+    private static final List<Integer>       SUCCESS_CODES = List.of(VI_SUCCESS, VI_SUCCESS_TERM_CHAR, VI_SUCCESS_MAX_CNT);
+
+    protected jisa.visa.VISANativeInterface lib;
+    protected NativeLong          visaResourceManagerHandle;
+
+    public RSVISADriver() {
+
+        lib                       = RSVISADriver.libStatic;
+        visaResourceManagerHandle = RSVISADriver.visaResourceManagerHandleStatic;
+
+        Util.addShutdownHook(() -> {
+
+            if (visaResourceManagerHandle != null) {
+                RSVISADriver.libStatic.viClose(RSVISADriver.visaResourceManagerHandleStatic);
+            }
+
+        });
+
+    }
+
+    public static void init() throws jisa.visa.VISAException
+    {
+
+        try {
+
+            if (OS_NAME.contains("win")) {
+                libName   = "RsVisa32";
+                libStatic = Native.loadLibrary(RSVISADriver.libName, jisa.visa.VISANativeInterface.class);
+            } else if (OS_NAME.contains("linux") || OS_NAME.contains("mac")) {
+                libName   = "visa";
+                libStatic = Native.loadLibrary(RSVISADriver.libName, VISANativeInterface.class);
+            } else {
+                throw new jisa.visa.VISAException("Platform not yet supported!");
+            }
+
+        } catch (UnsatisfiedLinkError e) {
+            libStatic = null;
+        }
+
+        if (libStatic == null) {
+            throw new jisa.visa.VISAException("Could not load VISA library");
+        }
+
+        // Attempt to get a resource manager handle
+        try {
+            visaResourceManagerHandleStatic = getResourceManager();
+        } catch (jisa.visa.VISAException e) {
+            throw new jisa.visa.VISAException("Could not get resource manager");
+        }
+
+    }
+
+    /**
+     * Sets up the resource manager for this session. Used only internally.
+     *
+     * @return Resource manager handle.
+     *
+     * @throws jisa.visa.VISAException When VISA does go gone screw it up
+     */
+    protected static NativeLong getResourceManager() throws jisa.visa.VISAException
+    {
+
+        NativeLongByReference pViSession = new NativeLongByReference();
+        NativeLong            visaStatus = RSVISADriver.libStatic.viOpenDefaultRM(pViSession);
+
+        if (visaStatus.longValue() != VI_SUCCESS) {
+            throw new jisa.visa.VISAException("Error opening resource manager!");
+        }
+        return pViSession.getValue();
+
+    }
+
+    /**
+     * Converts a string to bytes in a ByteBuffer, used for sending to VISA library which expects binary strings.
+     *
+     * @param source The string, damn you.
+     *
+     * @return The ByteBuffer that I mentioned.
+     */
+    protected static ByteBuffer stringToByteBuffer(String source) {
+        try {
+            ByteBuffer dest = ByteBuffer.allocate(source.length() + 1);
+            dest.put(source.getBytes(responseEncoding));
+            dest.position(0);
+            return dest;
+        } catch (UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public jisa.visa.Connection open(Address address) throws jisa.visa.VISAException
+    {
+
+        NativeLongByReference pViInstrument = new NativeLongByReference();
+
+        SerialAddress sAddr = address.toSerialAddress();
+        ByteBuffer    pViString;
+
+        if (sAddr != null) {
+            pViString = stringToByteBuffer(toVISASerial(sAddr));
+        } else {
+            pViString = stringToByteBuffer(address.toString());
+        }
+
+        if (pViString == null) {
+            throw new jisa.visa.VISAException("Error encoding address to ByteBuffer.");
+        }
+
+        NativeLong status = lib.viOpen(
+                visaResourceManagerHandle,
+                pViString,         // byte buffer for instrument string
+                new NativeLong(0), // access mode (locking or not). 0:Use Visa default
+                new NativeLong(0), // timeout, only when access mode equals locking
+                pViInstrument      // pointer to instrument object
+        );
+
+        if (status.longValue() == VI_SUCCESS) {
+
+            return new VISAConnection(pViInstrument.getValue());
+
+        } else {
+
+            switch (status.intValue()) {
+
+                case VI_ERROR_INV_OBJECT:
+                    throw new jisa.visa.VISAException("No resource manager is open to open \"%s\".", address.toString());
+
+                case VI_ERROR_INV_RSRC_NAME:
+                    throw new jisa.visa.VISAException("Invalid address: \"%s\".", address.toString());
+
+                case VI_ERROR_RSRC_NFOUND:
+                    throw new jisa.visa.VISAException("No resource found at \"%s\".", address.toString());
+
+                case VI_ERROR_RSRC_BUSY:
+                    throw new jisa.visa.VISAException("Resource busy at \"%s\".", address.toString());
+
+                case VI_ERROR_TMO:
+                    throw new jisa.visa.VISAException("Open operation timed out.");
+
+                default:
+                    throw new jisa.visa.VISAException("Error trying to open instrument connection. Status: %d", status.intValue());
+
+            }
+        }
+
+    }
+
+    protected NativeLong openInstrument(String address) {
+
+
+        NativeLongByReference pViInstrument = new NativeLongByReference();
+        ByteBuffer            pViString     = stringToByteBuffer(address);
+
+        NativeLong status = lib.viOpen(
+                visaResourceManagerHandle,
+                pViString,
+                new NativeLong(0),
+                new NativeLong(0),
+                pViInstrument
+        );
+
+        if (status.longValue() == VI_SUCCESS) {
+            return pViInstrument.getValue();
+        } else {
+            return null;
+        }
+
+    }
+
+    protected String toVISASerial(SerialAddress address) throws jisa.visa.VISAException
+    {
+
+        String raw = address.toString();
+
+        Pattern windows = Pattern.compile("ASRL::COM([0-9]*)::INSTR");
+        Matcher matcher = windows.matcher(raw);
+
+        if (matcher.find()) {
+
+            return String.format("ASRL%s::INSTR", matcher.group(1));
+
+        } else {
+
+            Pattern asrl  = Pattern.compile("ASRL([0-9]*?)::INSTR");
+            Pattern dfind = Pattern.compile("(COM([0-9]*))|(/dev/tty((S)|(USB))([0-9]*))");
+
+            for (StrAddress found : search(false)) {
+
+                Matcher aMatch = asrl.matcher(found.toString());
+
+                if (aMatch.find()) {
+
+                    String         number      = aMatch.group(1);
+                    VISAConnection con         = (VISAConnection) open(found);
+                    String         desc        = con.getAttributeString(VI_ATTR_INTF_INST_NAME);
+                    Matcher        portMatcher = dfind.matcher(desc);
+
+                    if (portMatcher.find()) {
+
+                        String port = portMatcher.group(0);
+
+                        if (port.trim().equals(address.getPort().trim())) {
+                            return found.toString();
+                        }
+
+                    }
+
+                }
+
+            }
+
+            throw new jisa.visa.VISAException("No resource found at \"%s\"", address.toString());
+
+        }
+
+    }
+
+    @Override
+    public StrAddress[] search() throws jisa.visa.VISAException
+    {
+        return search(true);
+    }
+
+    @Override
+    public boolean worksWith(Address address) {
+
+        switch (address.getType()) {
+
+            case ID:
+            case MODBUS:
+                return false;
+
+            default:
+                return true;
+
+        }
+
+    }
+
+    public StrAddress[] search(boolean changeSerial) throws jisa.visa.VISAException
+    {
+
+        // VISA RegEx for "Anything" (should be .* but they seem to use their own standard)
+        ByteBuffer            expr       = stringToByteBuffer("?*");
+        ByteBuffer            desc       = ByteBuffer.allocate(1024);
+        NativeLongByReference listHandle = new NativeLongByReference();
+        NativeLongByReference listCount  = new NativeLongByReference();
+
+        // Perform the native call
+        NativeLong status = lib.viFindRsrc(
+                visaResourceManagerHandle,
+                expr,
+                listHandle,
+                listCount,
+                desc
+        );
+
+        if (status.longValue() == VI_ERROR_RSRC_NFOUND) {
+            lib.viClose(listHandle.getValue());
+            return new StrAddress[0];
+        }
+
+        if (status.longValue() != VI_SUCCESS) {
+            lib.viClose(listHandle.getValue());
+            throw new jisa.visa.VISAException("Error searching for devices.");
+        }
+
+        int                   count     = listCount.getValue().intValue();
+        ArrayList<StrAddress> addresses = new ArrayList<>();
+        NativeLong            handle    = listHandle.getValue();
+        String                address;
+        Pattern               dfind     = Pattern.compile("(COM([0-9]*))|(/dev/tty((S)|(USB))([0-9]*))");
+        do {
+
+            try {
+                address = new String(desc.array(), 0, 1024, responseEncoding);
+            } catch (UnsupportedEncodingException e) {
+                throw new jisa.visa.VISAException("Unable to encode address!");
+            }
+
+            StrAddress strAddress = new StrAddress(address);
+
+            if (changeSerial && address.contains("ASRL")) {
+
+                try {
+
+                    VISAConnection c    = (VISAConnection) open(strAddress);
+                    String         intf = c.getAttributeString(VI_ATTR_INTF_INST_NAME);
+                    c.close();
+                    Matcher matcher = dfind.matcher(intf);
+
+                    if (matcher.find()) {
+                        String port = matcher.group(0);
+                        strAddress = new StrAddress(String.format("ASRL%s::INSTR", port.trim().replaceAll("[^0-9]", "")));
+                    }
+
+                } catch (Exception ignored) {}
+
+            }
+
+            addresses.add(strAddress);
+
+            desc = ByteBuffer.allocate(1024);
+
+        } while (lib.viFindNext(handle, desc).longValue() == VI_SUCCESS);
+
+        lib.viClose(handle);
+
+        return addresses.toArray(new StrAddress[0]);
+    }
+
+    public class VISAConnection implements Connection
+    {
+
+        protected NativeLong handle;
+
+        public VISAConnection(NativeLong viHandle) {
+            handle = viHandle;
+        }
+
+        @Override
+        public void writeBytes(byte[] bytes) throws jisa.visa.VISAException
+        {
+
+            ByteBuffer pBuffer = ByteBuffer.wrap(bytes);
+
+            long writeLength = bytes.length;
+
+            NativeLongByReference returnCount = new NativeLongByReference();
+
+            NativeLong status = lib.viWrite(
+                    handle,
+                    pBuffer,
+                    new NativeLong(writeLength),
+                    returnCount
+            );
+
+            if (status.longValue() < VI_SUCCESS) {
+
+                switch (status.intValue()) {
+
+                    case VI_ERROR_INV_OBJECT:
+                        throw new jisa.visa.VISAException("That connection is not open.");
+
+                    case VI_ERROR_TMO:
+                        throw new jisa.visa.VISAException("Write operation timed out.");
+
+                    default:
+                        throw new jisa.visa.VISAException("Error writing to instrument.");
+
+                }
+            }
+
+            if (returnCount.getValue().longValue() != writeLength) {
+                throw new jisa.visa.VISAException("Command was not fully sent!");
+            }
+
+        }
+
+        @Override
+        public void clear() throws jisa.visa.VISAException
+        {
+
+            NativeLong status = lib.viClear(handle);
+
+            if (status.intValue() != VI_SUCCESS) {
+                throw new jisa.visa.VISAException("Unable to clear connection.");
+            }
+
+        }
+
+        @Override
+        public void write(String toWrite) throws jisa.visa.VISAException
+        {
+
+            // Convert string to bytes to send
+            ByteBuffer pBuffer = stringToByteBuffer(toWrite);
+            if (pBuffer == null) {
+                throw new jisa.visa.VISAException("Error converting command to ByteBuffer");
+            }
+
+            long writeLength = toWrite.length();
+
+            NativeLongByReference returnCount = new NativeLongByReference();
+
+            NativeLong status = lib.viWrite(
+                    handle,
+                    pBuffer,
+                    new NativeLong(writeLength),
+                    returnCount
+            );
+
+            if (status.intValue() != VI_SUCCESS) {
+
+                switch (status.intValue()) {
+
+                    case VI_ERROR_INV_OBJECT:
+                        throw new jisa.visa.VISAException("That connection is not open.");
+
+                    case VI_ERROR_TMO:
+                        throw new jisa.visa.VISAException("Write operation timed out.");
+
+                    default:
+                        throw new jisa.visa.VISAException("Error writing to instrument.");
+
+                }
+            }
+
+            if (returnCount.getValue().longValue() != writeLength) {
+                throw new jisa.visa.VISAException("Command was not fully sent!");
+            }
+
+        }
+
+        @Override
+        public byte[] readBytes(int bufferSize) throws jisa.visa.VISAException
+        {
+
+            ByteBuffer            response    = ByteBuffer.allocate(bufferSize);
+            NativeLongByReference returnCount = new NativeLongByReference();
+            ByteArrayOutputStream longResponse = new ByteArrayOutputStream();
+
+            NativeLong status = lib.viRead(
+                    handle,
+                    response,
+                    new NativeLong(bufferSize),
+                    returnCount
+            );
+
+            switch (status.intValue()) {
+
+                case VI_SUCCESS:
+                case VI_SUCCESS_TERM_CHAR:
+                case VI_SUCCESS_MAX_CNT:
+                    try
+                    {
+                        longResponse.write(Arrays.copyOfRange(response.array(),0,returnCount.getValue().intValue()));
+                        while (status.intValue() == VI_SUCCESS_MAX_CNT || status.intValue() == VI_SUCCESS_TERM_CHAR)
+                        {
+                            status = lib.viRead(
+                                    handle,
+                                    response,
+                                    new NativeLong(bufferSize),
+                                    returnCount
+                            );
+                            longResponse.write(Arrays.copyOfRange(response.array(),0,returnCount.getValue().intValue()));
+                        }
+                        return longResponse.toByteArray();
+                    }
+                    catch (IOException e)
+                    {
+                        throw new jisa.visa.VISAException("Error reading all bytes from instrument, code: 0x%08X", status.intValue());
+                    }
+                case VI_ERROR_INV_OBJECT:
+                    throw new jisa.visa.VISAException("That connection is not open.");
+
+                case VI_ERROR_TMO:
+                    throw new jisa.visa.VISAException("Read operation timed out.");
+
+                default:
+                    throw new jisa.visa.VISAException("Error reading from instrument, code: 0x%08X", status.intValue());
+
+            }
+
+        }
+
+        @Override
+        public void setEOI(boolean set) throws jisa.visa.VISAException
+        {
+            setAttribute(VI_ATTR_SEND_END_EN, set ? VI_TRUE : VI_FALSE);
+        }
+
+        @Override
+        public void setReadTerminator(long character) throws jisa.visa.VISAException
+        {
+            setAttribute(VI_ATTR_TERMCHAR_EN, character != 0 ? VI_TRUE : VI_FALSE);
+            setAttribute(VI_ATTR_TERMCHAR, character);
+        }
+
+        @Override
+        public void setTimeout(int duration) throws jisa.visa.VISAException
+        {
+            setAttribute(VI_ATTR_TMO_VALUE, duration);
+        }
+
+        @Override
+        public void setSerial(int baud, int data, Parity parity, StopBits stop, Flow flow) throws jisa.visa.VISAException
+        {
+
+            setAttribute(VI_ATTR_ASRL_BAUD, baud);
+            setAttribute(VI_ATTR_ASRL_DATA_BITS, data);
+            setAttribute(VI_ATTR_ASRL_PARITY, parity.toInt());
+            setAttribute(VI_ATTR_ASRL_STOP_BITS, stop.toInt());
+            setAttribute(VI_ATTR_ASRL_FLOW_CNTRL, flow.toInt());
+
+        }
+
+        @Override
+        public void close() throws jisa.visa.VISAException
+        {
+
+            NativeLong status = lib.viClose(handle);
+
+            if (status.longValue() != VI_SUCCESS) {
+                throw new jisa.visa.VISAException("Error closing instrument!");
+            }
+
+        }
+
+        public void setAttribute(long attribute, long value) throws jisa.visa.VISAException
+        {
+
+            NativeLong status = lib.viSetAttribute(
+                    handle,
+                    new NativeLong(attribute),
+                    new NativeLong(value)
+            );
+
+            if (status.longValue() != VI_SUCCESS) {
+                throw new jisa.visa.VISAException("Error setting attribute.");
+            }
+
+        }
+
+        public long getAttributeLong(long attribute) throws jisa.visa.VISAException
+        {
+
+            NativeLongByReference pointer = new NativeLongByReference();
+
+            NativeLong status = lib.viGetAttribute(
+                    handle,
+                    new NativeLong(attribute),
+                    pointer.getPointer()
+            );
+
+            return pointer.getValue().longValue();
+
+        }
+
+        public String getAttributeString(long attribute) throws VISAException
+        {
+
+            Pointer pointer = new Memory(VI_FIND_BUFLEN);
+
+            NativeLong status = lib.viGetAttribute(
+                    handle,
+                    new NativeLong(attribute),
+                    pointer
+            );
+
+            return pointer.getString(0);
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Implemented changes, as discussed per mail:

•	Interface “IVSource”. Added two methods “getSetVoltage()” and “getSetCurrent()” to read back the value which was set and not the currently displayed value. For the devices we do not have in house a "Not implemented" DeviceException will be thrown.

•	Added constructor to “USBAddress” to be able to just copy paste the playin USB address.

•	Interface “DCPower”. Added a method “setCurrentLimit()”, because we need every supply to have this functionality.

•	To be RSVisa compliant added “RSVISADriver” and a try catch block to “VISA”. 
(Driver download: https://www.rohde-schwarz.com/at/applikationen/r-s-visa-application-note_56280-148812.html)

•	JavaFX thread troubles. Fixed with a “try-catch” loop, which increases a sleep if the exception is thrown, up to one second. We never encountered it again, but if it still occurs the sleep time or RETRY_COUNT can be increased. 
NOTE: Was added as extra "/src/jisa/gui/JavaFX.java" file; (commented JavaFX import in GUI.java)

Additionally I commented out "manuallyClearBuffer()" in  "src/jisa/devices/smu/KeithleySCPI.java", because on our side it causes the instrument to display error on every new connection and we did not encountered problems without it.
